### PR TITLE
refactor: Accounting for the service termination block conditions

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -9,9 +9,7 @@ import "./interfaces/IRegistry.sol";
 /// @title Agent Registry - Smart contract for registering agents
 /// @author Aleksandr Kuperman - <aleksandr.kuperman@valory.xyz>
 contract AgentRegistry is IMultihash, ERC721Enumerable, Ownable, ReentrancyGuard {
-    // Possible differentiation of component types
-    enum AgentType {ATYPE0, ATYPE1}
-
+    // Agent parameters
     struct Agent {
         // Developer of the agent
         address developer;
@@ -23,8 +21,6 @@ contract AgentRegistry is IMultihash, ERC721Enumerable, Ownable, ReentrancyGuard
         uint256[] dependencies;
         // Agent activity
         bool active;
-        // Agent type
-        AgentType componentType;
     }
 
     // Component registry

--- a/contracts/ComponentRegistry.sol
+++ b/contracts/ComponentRegistry.sol
@@ -9,9 +9,7 @@ import "./interfaces/IRegistry.sol";
 /// @title Component Registry - Smart contract for registering components
 /// @author Aleksandr Kuperman - <aleksandr.kuperman@valory.xyz>
 contract ComponentRegistry is IMultihash, ERC721Enumerable, Ownable, ReentrancyGuard {
-    // Possible differentiation of component types
-    enum ComponentType {CTYPE0, CTYPE1}
-
+    // Component parameters
     struct Component {
         // Developer of the component
         address developer;
@@ -23,8 +21,6 @@ contract ComponentRegistry is IMultihash, ERC721Enumerable, Ownable, ReentrancyG
         uint256[] dependencies;
         // Component activity
         bool active;
-        // Component type
-        ComponentType componentType;
     }
 
     // Base URI


### PR DESCRIPTION
### Removing component and agent types prototypes.

### Accounting for the service termination block conditions in other service states.

- Safe should not be creatable and agent not registrable if the termination block has passed.
- Termination block must be editable if agent already start registering.

### Adding related tests

- 99 tests in total.
- Full test coverage is now broken due to governance contracts being not fully tested.