### PR TITLE
fix: fixed critical termination block condition

### DIFF
--- a/contracts/ServiceRegistry.sol
+++ b/contracts/ServiceRegistry.sol
@@ -399,7 +399,7 @@ contract ServiceRegistry is IMultihash, Ownable {
         require(service.deadline > block.timestamp, "registerAgent: TIMEOUT");
 
         // Check if the termination block has not passed
-        require(service.terminationBlock <= block.number, "registerAgent: TERMINATED");
+        require(service.terminationBlock == 0 || service.terminationBlock >= block.number, "registerAgent: TERMINATED");
 
         // Check if canonical agent Id exists in the service
         require(service.mapAgentSlots[agentId] > 0, "registerAgent: NO_AGENT");
@@ -466,7 +466,7 @@ contract ServiceRegistry is IMultihash, Ownable {
         require(service.numAgentInstances == service.maxNumAgentInstances, "createSafe: NUM_INSTANCES");
 
         // Check if the termination block has not passed
-        require(service.terminationBlock < block.number, "createSafe: TERMINATED");
+        require(service.terminationBlock == 0 || service.terminationBlock >= block.number, "createSafe: TERMINATED");
 
         // Get all agent instances for the safe
         address[] memory agentInstances = _getAgentInstances(service);

--- a/test/unit/ServiceRegistry.js
+++ b/test/unit/ServiceRegistry.js
@@ -623,7 +623,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
             await serviceRegistry.connect(serviceManager).activate(owner, serviceId);
-            await serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, 1000);
+            await serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, 1);
             await expect(
                 serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance, agentId)
             ).to.be.revertedWith("registerAgent: TERMINATED");
@@ -692,7 +692,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.connect(serviceManager).activate(owner, serviceId);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstances[0], agentId);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstances[1], agentId);
-            await serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, 1000);
+            await serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, 1);
             await expect(
                 serviceRegistry.connect(serviceManager).createSafe(owner, serviceId, AddressZero, "0x",
                     AddressZero, AddressZero, 0, AddressZero, serviceId)


### PR DESCRIPTION
Fixed the termination block condition, that must satisfy the following:
The service can register new agent instances and / or deploy safe when
- the termination block is equal to 0, meaning that the service never expires, or
- the termination block is greater or equal than the current block number, meaning that there are still epochs to process before the termination block is hit.