### PR TITLE
Deadlines for agent instance registration and service termination

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,7 @@
+# Authors
+
+This is the official list of Valory.xyz authors for copyright purposes.
+
+* Akeksandr Kuperman <aleksandr.kuperman@valory.xyz> [Kupermind](https://github.com/kupermind)
+* Andrey Lebedev <andrey.lebedev@valory.xyz> [77ph](https://github.com/77ph)
+* David Minarsch <davidm@valory.xyz> [DavidMinarsch](https://github.com/DavidMinarsch)

--- a/contracts/ServiceManager.sol
+++ b/contracts/ServiceManager.sol
@@ -92,8 +92,9 @@ contract ServiceManager is IMultihash, Ownable {
 
     /// @dev Activates the service and its sensitive components.
     /// @param serviceId Correspondent service Id.
-    function serviceActivateRegistration(uint256 serviceId) public {
-        IService(serviceRegistry).activateRegistration(msg.sender, serviceId);
+    /// @param deadline Agent instance registration deadline.
+    function serviceActivateRegistration(uint256 serviceId, uint256 deadline) public {
+        IService(serviceRegistry).activateRegistration(msg.sender, serviceId, deadline);
     }
 
     /// @dev Deactivates the service and its sensitive components.

--- a/contracts/interfaces/IErrors.sol
+++ b/contracts/interfaces/IErrors.sol
@@ -77,13 +77,13 @@ interface IErrors {
     /// @dev Zero value when it has to be greater than zero.
     error ZeroValue();
 
-    /// @dev Service is inactive.
+    /// @dev Service must be active.
     /// @param serviceId Service Id.
-    error ServiceInactive(uint256 serviceId);
+    error ServiceMustBeActive(uint256 serviceId);
 
-    /// @dev Service is active.
+    /// @dev Service must be inactive.
     /// @param serviceId Service Id.
-    error ServiceActive(uint256 serviceId);
+    error ServiceMustBeInactive(uint256 serviceId);
 
     /// @dev Agent instance registration deadline has been reached. Service is expired.
     /// @param deadline The registration deadline.

--- a/contracts/interfaces/IService.sol
+++ b/contracts/interfaces/IService.sol
@@ -10,7 +10,7 @@ interface IService is IMultihash {
     /**
      * @dev Activates the ``serviceId`` of the ``owner``.
      */
-    function activateRegistration(address owner, uint256 serviceId) external;
+    function activateRegistration(address owner, uint256 serviceId, uint256 deadline) external;
 
     /**
      * @dev Deactivates the ``serviceId`` of the ``owner``.

--- a/docs/FSM.md
+++ b/docs/FSM.md
@@ -1,6 +1,6 @@
 # On-Chain Protocol State Machine
 Let's first describe the list of possible states:
-- Service is non-existent; -> No service has been registered with a specified Id yet
+- Service is non-existent; -> No service has been registered with a specified Id yet or the service is non-recoverable
 - Service is pre-registration; -> Agent instance registration is not active yet
 - Service is active-registration; -> Agent instance registration is ongoing
 - Service is expired-registration; -> Deadline for agent instance registration has passed
@@ -8,7 +8,7 @@ Let's first describe the list of possible states:
 - Service is deployed; -> Service is deployed and operates via created safe contract
 - Service is terminated-bonded; -> Some agents are bonded with stake
 - Service is terminated-unbonded; -> All agents have left the service and recovered their stake
-- Service is destroyed; -> Service is no longer available
+- Service is destroyed; -> Service is no longer available: in the code it is a synonym to a non-existent state
 
 
 TBD: we need the bonding mechanism implemented as part of agent registration.
@@ -224,48 +224,39 @@ List of next possible states:
     - Function call for this state: **createSafe()**
 
 ### Service is expired-registration
-Condition for this state: Agent instance registration time has passed
+Condition for this state: Agent instance registration time has passed and previous service state was `active-registration`
 
 Functions to call from this state:
-  - **activateRegistration()**
   - **deactivateRegistration()**
   - **destroy()**
-  - **update()**. Condition: No single agent instance is registered or previous service state was `pre-registration`
-  - **createSafe()**
+  - **update()**. Condition: No single agent instance is registered.
   - **setRegistrationDeadline()**
   - **setTerminationBlock()**
+
 
 List of next possible states:
 1. **Service is active-registration**
     - Function call for this state: **setRegistrationDeadline()**
-    - Condition: Previous service state was `active-registration` and updated time is greater than the current time
+    - Condition: Updated time is greater than the current time and no single agent instance was registered
 
 
 2. **Service is pre-registration**
-    - Function call for this state: **setRegistrationDeadline()**
-    - Condition: Previous service state was `pre-registration` and updated time is greater than the current time
+    - Function call for this state: **deactivateRegistration()**
+    - Condition: No single agent instance is currently registered
 
 
-2. **Service is destroyed**
+3. **Service is destroyed**
     - Function call for this state: **destroy()**
-    - Condition: Previous service state was `pre-registration`. Or, no single agent instance is registered
+    - Condition: No single agent instance is currently registered
 
-3. **Service is deployed**
-    - Function call for this state: **createSafe()**
-    - Condition: Previous service state was `finished-registration`
-
-
-4. **Service is finished-registration**
-    - Function call for this state: **setRegistrationDeadline()**
-    - Condition: Previous service state was `finished-registration` and updated time is greater than the current time
-    
 ### Service is terminated-bonded
 Condition for this state: Service termination block has passed and some agents are bonded with stake. DOES THIS COUNT FOR BEFORE THE SERVICE IS DEPLOYED AS WELL?
 
 Functions to call from this state:
   - **setTerminationBlock()**
 
-    
+
+List of next possible states:    
 1. **Service is deployed**
     - Function call for this state: **setTerminationBlock()**
     - Condition: Previous service state was `deployed` and updated termination block is equal to zero or greater than the current block number
@@ -279,25 +270,11 @@ Functions to call from this state:
 Condition for this state: Service termination block has passed and all agent instances have left the service and recovered their stake or have never registered for the service
 
 Functions to call from this state:
-- **activateRegistration()** WHAT DOES THIS DO? TBD; why new registration when terminated? how do we rotate agents -> happens at safe level? (whould be easier; but then slashing also needs to happen there)
-- **deactivateRegistration()** WHY relevant?
 - **destroy()**
-- **update()**. Condition: No single agent instance is registered or previous service state was `pre-registration`
-- **setRegistrationDeadline()**
-- **setTerminationBlock()**
+- **update()** -> Can be called, but will not do anything useful
+- **setTerminationBlock()** -> Can be called, but will not do anything useful
 
 
 List of next possible states:
 1. **Service is destroyed**
     - Function call for this state: **destroy()**
-    - Condition: Previous service state was `pre-registration` or no single agent instance is registered
-
-
-2. **Service is active-registration**
-    - Function call for this state: **setTerminationBlock()**
-    - Condition: Previous service state was `active-registration` and updated termination block is equal to zero or greater than the current block number
-
-
-3. **Service is pre-registration**
-    - Function call for this state: **setTerminationBlock()**
-    - Condition: Previous service state was `pre-registration` and updated termination block is equal to zero or greater than the current block number

--- a/test/unit/ServiceRegistry.js
+++ b/test/unit/ServiceRegistry.js
@@ -20,7 +20,12 @@ describe("ServiceRegistry", function () {
     const componentHash = {hash: "0x" + "0".repeat(64), hashFunction: "0x12", size: "0x20"};
     const componentHash1 = {hash: "0x" + "1".repeat(64), hashFunction: "0x12", size: "0x20"};
     const componentHash2 = {hash: "0x" + "2".repeat(64), hashFunction: "0x12", size: "0x20"};
+    const agentHash = {hash: "0x" + "7".repeat(64), hashFunction: "0x12", size: "0x20"};
+    const agentHash1 = {hash: "0x" + "8".repeat(64), hashFunction: "0x12", size: "0x20"};
     const AddressZero = "0x" + "0".repeat(40);
+    // Deadline must be bigger than minimum deadline plus current block number. However hardhat keeps on increasing
+    // block number for each test, so we set a high enough value here, and in time sensitive tests use current blocks
+    const regDeadline = 100000;
     beforeEach(async function () {
         const ComponentRegistry = await ethers.getContractFactory("ComponentRegistry");
         componentRegistry = await ComponentRegistry.deploy("agent components", "MECHCOMP",
@@ -293,7 +298,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance, agentId);
             await expect(
                 serviceRegistry.connect(serviceManager).update(owner, name, description, configHash, agentIds,
@@ -364,7 +369,7 @@ describe("ServiceRegistry", function () {
                 agentNumSlots, maxThreshold);
             await expect(
                 serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance, agentId)
-            ).to.be.revertedWith("ServiceInactive");
+            ).to.be.revertedWith("WrongServiceState");
         });
 
         it("Should fail when registering an agent instance that is already registered", async function () {
@@ -381,7 +386,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance, agentId);
             await expect(
                 serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance, agentId)
@@ -401,7 +406,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             await expect(
                 serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance, 0)
             ).to.be.revertedWith("AgentNotInService");
@@ -420,7 +425,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance[0], agentId);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance[1], agentId);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance[2], agentId);
@@ -442,7 +447,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             const regAgent = await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId,
                 agentInstance, agentId);
             const result = await regAgent.wait();
@@ -464,8 +469,8 @@ describe("ServiceRegistry", function () {
                 agentNumSlots, maxThreshold);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1, regDeadline);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance[0], agentId);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId + 1, agentInstance[1], agentId);
             const regAgent = await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId,
@@ -487,7 +492,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             await expect(
                 serviceRegistry.connect(serviceManager).registerAgent(agentInstances[0], serviceId, agentInstances[0], agentId)
             ).to.be.revertedWith("WrongOperator");
@@ -502,7 +507,7 @@ describe("ServiceRegistry", function () {
         it("Should fail when activating a service without a serviceManager", async function () {
             const owner = signers[3].address;
             await expect(
-                serviceRegistry.activateRegistration(owner, serviceId)
+                serviceRegistry.activateRegistration(owner, serviceId, regDeadline)
             ).to.be.revertedWith("ManagerOnly");
         });
 
@@ -511,7 +516,7 @@ describe("ServiceRegistry", function () {
             const owner = signers[4].address;
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1)
+                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1, regDeadline)
             ).to.be.revertedWith("ServiceNotFound");
         });
 
@@ -526,10 +531,10 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             await expect(
-                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId)
-            ).to.be.revertedWith("ServiceActive");
+                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline)
+            ).to.be.revertedWith("ServiceMustBeInactive");
         });
 
         it("Catching \"ActivateRegistration\" event log after service activation", async function () {
@@ -543,7 +548,8 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            const activateService = await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            const activateService = await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId,
+                regDeadline);
             const result = await activateService.wait();
             expect(result.events[0].event).to.equal("ActivateRegistration");
         });
@@ -561,7 +567,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance, agentId);
             await expect(
                 serviceRegistry.connect(serviceManager).deactivateRegistration(owner, serviceId)
@@ -581,7 +587,7 @@ describe("ServiceRegistry", function () {
                 agentNumSlots, maxThreshold);
             await expect(
                 serviceRegistry.connect(serviceManager).deactivateRegistration(owner, serviceId)
-            ).to.be.revertedWith("ServiceInactive");
+            ).to.be.revertedWith("ServiceMustBeActive");
         });
 
         it("Catching \"DeactivateRegistration\" event log after service deactivation", async function () {
@@ -595,7 +601,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             const deactivateService = await serviceRegistry.connect(serviceManager).deactivateRegistration(owner, serviceId);
             const result = await deactivateService.wait();
             expect(result.events[0].event).to.equal("DeactivateRegistration");
@@ -614,11 +620,11 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance, agentId);
             await expect(
                 serviceRegistry.connect(serviceManager).destroy(owner, serviceId)
-            ).to.be.revertedWith("ServiceActive");
+            ).to.be.revertedWith("ServiceMustBeInactive");
         });
 
         it("Catching \"DestroyService\" event. Service is destroyed without agent instances", async function () {
@@ -632,7 +638,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             const deactivateService = await serviceRegistry.connect(serviceManager).destroy(owner, serviceId);
             const result = await deactivateService.wait();
             expect(result.events[0].event).to.equal("DestroyService");
@@ -653,16 +659,25 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
-            await serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, 1);
-            await expect(
-                serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance, agentId)
-            ).to.be.revertedWith("ServiceTerminated");
+
+            // Activate agent instance registration and register an agent
+            const nBlocks = Number(await serviceRegistry.getMinRegistrationDeadline());
+            const blockNumber = await ethers.provider.getBlockNumber();
+            // Deadline must be bigger than a current block number plus the minimum registration deadline
+            const tDeadline = blockNumber + nBlocks + 10;
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline);
+            await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance, agentId);
+            // Termination block must be further than the registration deadline
+            await serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, tDeadline + 10);
+            // Mining past the termination block
+            for (let i = blockNumber; i <= tDeadline + 11; i++) {
+                ethers.provider.send("evm_mine");
+            }
+            // At this point of time the service must be terminated-bonded, sine the instance was not unbonded
+            // But since we never deployed, it's good with just expired-registration
             const state = await serviceRegistry.getServiceState(serviceId);
-            expect(state).to.equal(7);
-            await serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, 0);
-            serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance, agentId);
-            await serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, 1);
+            expect(state).to.equal(3);
+            // Destroy the service
             const deactivateService = await serviceRegistry.connect(serviceManager).destroy(owner, serviceId);
             const result = await deactivateService.wait();
             expect(result.events[0].event).to.equal("DestroyService");
@@ -679,9 +694,9 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, 1000);
+            await serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, regDeadline + 10);
             const tBlock = await serviceRegistry.getTerminationBlock(serviceId);
-            expect(tBlock).to.equal(1000);
+            expect(tBlock).to.equal(regDeadline + 10);
             const deactivateService = await serviceRegistry.connect(serviceManager).destroy(owner, serviceId);
             const result = await deactivateService.wait();
             expect(result.events[0].event).to.equal("DestroyService");
@@ -702,7 +717,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentNumSlots, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstance, agentId);
             await expect(
                 serviceRegistry.connect(serviceManager).createSafe(owner, serviceId, AddressZero, "0x", AddressZero,
@@ -715,37 +730,53 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             const operator = signers[6].address;
-            const agentInstances = [signers[7].address, signers[8].address];
-            const maxThreshold = 2;
+            const agentInstances = [signers[7].address, signers[8].address, signers[9].address];
+            const maxThreshold = 3;
 
-            // Create a component
+            // Create components
             await componentRegistry.changeManager(mechManager.address);
             await componentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
+            await componentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, [1]);
 
-            // Create an agent
+            // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash2, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1, 2]);
 
             // Create a service and activate the agent instance registration
             let state = await serviceRegistry.getServiceState(serviceId);
             expect(state).to.equal(0);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1], [2],
-                maxThreshold);
+            await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1, 2],
+                [2, 1], maxThreshold);
             state = await serviceRegistry.getServiceState(serviceId);
             expect(state).to.equal(1);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+
+            const nBlocks = Number(await serviceRegistry.getMinRegistrationDeadline());
+            const blockNumber = await ethers.provider.getBlockNumber();
+            // Deadline must be bigger than a current block number plus the minimum registration deadline
+            const tDeadline = blockNumber + nBlocks + 10;
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline);
             state = await serviceRegistry.getServiceState(serviceId);
             expect(state).to.equal(2);
+            const registartionDeadline = await serviceRegistry.getRegistrationDeadline(serviceId);
+            expect(registartionDeadline).to.equal(tDeadline);
 
             /// Register agent instances
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstances[0], agentId);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstances[1], agentId);
+            await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstances[2], agentId + 1);
             state = await serviceRegistry.getServiceState(serviceId);
             expect(state).to.equal(4);
 
-            // Set termination block and try to deploy the service. It must fail as termination block has passed
-            await serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, 1);
+            // Set termination block, reach it and try to deploy the service. It must fail as termination block has passed
+            const tBlock = tDeadline + 10;
+            await serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, tBlock);
+            // Reach after the termination block
+            for (let i = blockNumber; i <= tBlock; i++) {
+                ethers.provider.send("evm_mine");
+            }
+            // At this point of time, the service is terminated
             state = await serviceRegistry.getServiceState(serviceId);
             expect(state).to.equal(6);
             await expect(
@@ -771,6 +802,48 @@ describe("ServiceRegistry", function () {
                 expect(serviceIdFromComponentId.numServiceIds).to.equal(1);
                 expect(serviceIdFromComponentId.serviceIds[0]).to.equal(serviceId);
             }
+        });
+
+        it("Making sure we get correct mapping of _mapComponentIdSetServices formed", async function () {
+            const mechManager = signers[3];
+            const serviceManager = signers[4];
+            const owner = signers[5].address;
+            const operator = signers[6].address;
+            const agentInstances = [signers[7].address, signers[8].address, signers[9].address, signers[10].address];
+            const maxThreshold = 2;
+
+            // Create components
+            await componentRegistry.changeManager(mechManager.address);
+            await componentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
+            await componentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, [1]);
+
+            // Create agents
+            await agentRegistry.changeManager(mechManager.address);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1, 2]);
+
+            // Create services and activate the agent instance registration
+            let state = await serviceRegistry.getServiceState(serviceId);
+            expect(state).to.equal(0);
+            await serviceRegistry.changeManager(serviceManager.address);
+            await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1],
+                [2], maxThreshold);
+            await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash1, [2],
+                [2], maxThreshold);
+
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1, regDeadline);
+
+            /// Register agent instances
+            await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstances[0], agentId);
+            await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstances[1], agentId);
+            await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId + 1, agentInstances[2], agentId + 1);
+            await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId + 1, agentInstances[3], agentId + 1);
+
+            const safe1 = await serviceRegistry.connect(serviceManager).createSafe(owner, serviceId, AddressZero, "0x",
+                AddressZero, AddressZero, 0, AddressZero, serviceId);
+            const safe2 = await serviceRegistry.connect(serviceManager).createSafe(owner, serviceId + 1, AddressZero, "0x",
+                AddressZero, AddressZero, 0, AddressZero, serviceId);
         });
     });
 
@@ -816,7 +889,6 @@ describe("ServiceRegistry", function () {
             expect(serviceInfo.owner).to.equal(owner);
             expect(serviceInfo.name).to.equal(name);
             expect(serviceInfo.description).to.equal(description);
-            expect(serviceInfo.active).to.equal(false);
             expect(serviceInfo.numAgentIds).to.equal(agentIds.length);
             expect(serviceInfo.configHash.hash).to.equal(configHash.hash);
             for (let i = 0; i < agentIds.length; i++) {
@@ -862,7 +934,6 @@ describe("ServiceRegistry", function () {
             expect(serviceInfo.owner).to.equal(owner);
             expect(serviceInfo.name).to.equal(name);
             expect(serviceInfo.description).to.equal(description);
-            expect(serviceInfo.active).to.equal(false);
             expect(serviceInfo.numAgentIds).to.equal(agentIds.length);
             const agentIdsCheck = [newAgentIds[0], newAgentIds[2]];
             for (let i = 0; i < agentIds.length; i++) {
@@ -900,7 +971,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1], [2],
                 maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId);
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstances[0], agentId);
             await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstances[1], agentId);
 
@@ -921,6 +992,150 @@ describe("ServiceRegistry", function () {
             await expect(
                 serviceRegistry.getConfigHashes(1)
             ).to.be.revertedWith("ServiceDoesNotExist");
+        });
+    });
+
+    context("Deadlines", async function () {
+        it("Manipulations with registration deadlines", async function () {
+            const mechManager = signers[3];
+            const serviceManager = signers[4];
+            const owner = signers[5].address;
+            const operator = signers[6].address;
+            const agentInstances = [signers[7].address, signers[8].address];
+            const maxThreshold = 2;
+
+            // Create a component
+            await componentRegistry.changeManager(mechManager.address);
+            await componentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
+
+            // Create an agent
+            await agentRegistry.changeManager(mechManager.address);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash2, description, [1]);
+
+            // Create a service and activate the agent instance registration
+            await serviceRegistry.changeManager(serviceManager.address);
+            await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1], [2],
+                maxThreshold);
+
+            const nBlocks = Number(await serviceRegistry.getMinRegistrationDeadline());
+            const blockNumber = await ethers.provider.getBlockNumber();
+            // Deadline must be bigger than a current block number plus the minimum registration deadline
+            const tDeadline = blockNumber + nBlocks + 10;
+            // Rejects if the registration deadline is not bigger than the minimum deadline
+            await expect(
+                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, blockNumber + nBlocks)
+            ).to.be.revertedWith("RegistrationDeadlineIncorrect");
+            // Now deadline has a correct value
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline);
+
+            /// Register agent instances
+            await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstances[0], agentId);
+            await serviceRegistry.connect(serviceManager).registerAgent(operator, serviceId, agentInstances[1], agentId);
+
+            // Since all instances are registered, we can change the deadline now to the current block
+            const newBlockNumber = await ethers.provider.getBlockNumber() + 1;
+            await serviceRegistry.connect(serviceManager).setRegistrationDeadline(owner, serviceId, newBlockNumber);
+
+            // Cannot go below current block though
+            await expect(
+                serviceRegistry.connect(serviceManager).setRegistrationDeadline(owner, serviceId, 0)
+            ).to.be.revertedWith("RegistrationDeadlineIncorrect");
+
+            // It is not allowed also to move to a bigger block when all the instances are registered
+            await expect(
+                serviceRegistry.connect(serviceManager).setRegistrationDeadline(owner, serviceId, newBlockNumber + 10)
+            ).to.be.revertedWith("RegistrationDeadlineChangeRedundant");
+        });
+
+        it("Registration deadlines and termination blocks", async function () {
+            const mechManager = signers[3];
+            const serviceManager = signers[4];
+            const owner = signers[5].address;
+            const maxThreshold = 2;
+
+            // Create a component
+            await componentRegistry.changeManager(mechManager.address);
+            await componentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
+
+            // Create an agent
+            await agentRegistry.changeManager(mechManager.address);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash2, description, [1]);
+
+            // Create a service and activate the agent instance registration
+            await serviceRegistry.changeManager(serviceManager.address);
+            await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1], [2],
+                maxThreshold);
+
+            // If not infinite, termination block must be bigger than the minimum registration deadline
+            await expect(
+                serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, 1)
+            ).to.be.revertedWith("TerminationBlockIncorrect");
+
+            const nBlocks = Number(await serviceRegistry.getMinRegistrationDeadline());
+            const blockNumber = await ethers.provider.getBlockNumber();
+            // Deadline must be bigger than a current block number plus the minimum registration deadline
+            const tDeadline = blockNumber + nBlocks + 10;
+            // Setting the termination block above the registration deadline
+            serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, tDeadline + 10);
+            // Trying to activate the registration with the deadline bigger than the termination block fails
+            await expect(
+                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline + 20)
+            ).to.be.revertedWith("TerminationBlockIncorrect");
+
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline);
+
+            // Trying to set the termination block not bigger than the registration deadline block results in an error
+            await expect(
+                serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, tDeadline)
+            ).to.be.revertedWith("TerminationBlockIncorrect");
+        });
+
+        it("Setting different registration deadlines", async function () {
+            const mechManager = signers[3];
+            const serviceManager = signers[4];
+            const owner = signers[5].address;
+            const maxThreshold = 2;
+
+            // Create a component
+            await componentRegistry.changeManager(mechManager.address);
+            await componentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
+
+            // Create an agent
+            await agentRegistry.changeManager(mechManager.address);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash2, description, [1]);
+
+            // Create a service and activate the agent instance registration
+            await serviceRegistry.changeManager(serviceManager.address);
+            await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1], [2],
+                maxThreshold);
+
+            // Trying to set the registration deadline before the registration is activated
+            await expect(
+                serviceRegistry.connect(serviceManager).setRegistrationDeadline(owner, serviceId, regDeadline)
+            ).to.be.revertedWith("WrongServiceState");
+
+            const nBlocks = Number(await serviceRegistry.getMinRegistrationDeadline());
+            const blockNumber = await ethers.provider.getBlockNumber();
+            // Deadline must be bigger than a current block number plus the minimum registration deadline
+            const tDeadline = blockNumber + nBlocks + 10;
+            // Setting the termination block above the registration deadline
+            serviceRegistry.connect(serviceManager).setTerminationBlock(owner, serviceId, tDeadline + 10);
+            // Trying to activate the registration with the deadline bigger than the termination block fails
+            await expect(
+                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline + 20)
+            ).to.be.revertedWith("TerminationBlockIncorrect");
+
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline);
+
+            // Trying to change the termination deadline below the minimum on while no one has registered yet
+            await expect(
+                serviceRegistry.connect(serviceManager).setRegistrationDeadline(owner, serviceId, nBlocks)
+            ).to.be.revertedWith("RegistrationDeadlineIncorrect");
+
+            // Trying to change the termination deadline bigger than the termination block
+            await expect(
+                serviceRegistry.connect(serviceManager).setRegistrationDeadline(owner, serviceId, tDeadline + 20)
+            ).to.be.revertedWith("TerminationBlockIncorrect");
         });
     });
 });


### PR DESCRIPTION
### Not for immediate merge
- Changed `setRegistrationWindow` to `setRegistrationDeadline` since it makes more logical sense;
- Addressed agent instance registration and service termination deadlines validity;
- Some tests fail and this is normal since they need to be updated.

### Discussion
I believe that we should not give the ability to freely change the agent instance registration deadline to the service owner. This makes things very unpredictable, especially considering the fact that operators can't leave the service. They can't register to a different service either with their agent instance since the service registry will reject it (they are already registered with another service, although idle and might never run at all). I would suggest considering the workflow similar to parachains:
- when the service registration is activated, all the services are given a (substantial) deadline for operators to register their agent instances;
- the service owner only can change the registration deadline once all the instances are filled, and only to the time less than the initial deadline. This shall be the case for all further possible deadline changes;
- or once all the instances are registered, the registration time is changed to (for example) 24 hours from the very last instance registration, such that all the operators know exactly when the service starts (also somehow have to make sure the service is deployed by the owner after that holding time);
- if the deadline is passed and the service didn't have all the agent instances registered, they are all released, and the service goes into the pre-registration state. It can then be reactivated or destroyed. Although I'm not sure how to do the part of changing the service to pre-registration state without payment, since that operation incurs the data change;
- operators should not be given the ability to leave the service except for the case when the deadline is reached and the service is not in a full capacity of instances, since this will create a mess for services. Particularly it will be very difficult to predict if any of them would be deployed at all;
- however, there should be the ability to leave the service once the deadline has passed and the service is not ready. The owner can move the registration deadline infinitely, or don't do anything after the deadline has reached, and agent instances will be trapped in a specific service that might never run.