### PR TITLE
feat: owner makes deposite to activate registration

### DIFF
--- a/contracts/interfaces/IErrors.sol
+++ b/contracts/interfaces/IErrors.sol
@@ -138,11 +138,11 @@ interface IErrors {
     /// @dev Fallback or receive function.
     error WrongFunction();
 
-    /// @dev Insufficient deposit provided for the registration activation.
+    /// @dev Incorrect deposit provided for the registration activation.
     /// @param sent Sent amount.
     /// @param expected Expected amount.
     /// @param serviceId Service Id.
-    error InsufficientRegistrationDepositValue(uint256 sent, uint256 expected, uint256 serviceId);
+    error IncorrectRegistrationDepositValue(uint256 sent, uint256 expected, uint256 serviceId);
 
     /// @dev Insufficient value provided for the agent instance bonding.
     /// @param sent Sent amount.

--- a/docs/FSM.md
+++ b/docs/FSM.md
@@ -28,20 +28,6 @@ of the asynchronous on-chain behavior.
      - Output: Updates instance of `service Id`
    - **Next state:** Service is pre-registration
 
-
-2. - **Current state:** Service is active-registration
-     - Input: service parameters without errors and `service Id`
-     - Condition: No single agent instance is registered
-     - Output: Updates instance of `service Id`
-   - **Next state:** Service is active-registration
-
-
-3- **Current state:** Service is active-registration
-     - Input: service parameters without errors and `service Id`
-     - Condition: One or more agent instance is registered
-     - Output: Error
-   - **Next state:** Service is active-registration
-
 ### activateRegistration()
 1. - **Current state:** Service is pre-registration
    - **Next state:** Service is active-registration
@@ -160,7 +146,6 @@ List of next possible states:
 ### Service is active-registration
 Functions to call from this state:
   - **registerAgent()**
-  - **update()**. Condition: No single agent instance is registered
   - **setRegistrationDeadline()**
   - **terminate()**
 
@@ -197,7 +182,6 @@ List of next possible states:
 Condition for this state: Agent instance registration time has passed and previous service state was `active-registration`
 
 Functions to call from this state:
-  - **update()**. Condition: No single agent instance is registered.
   - **setRegistrationDeadline()**
   - **terminate()**
 
@@ -215,7 +199,7 @@ List of next possible states:
 
 3. **Service is terminated-unbonded**
     - Function call for this state: **terminate()**
-    - Condition: No single agent instance is currently registered.
+    - Condition: No single agent instance is currently registered
     
 ### Service is terminated-bonded
 Condition for this state: Service is terminated and some agents are bonded with agent instances.
@@ -234,7 +218,6 @@ Condition for this state: Service termination block has passed and all agent ins
 
 Functions to call from this state:
 - **destroy()**
-- **update()** -> Can be called, but will not do anything useful
 
 List of next possible states:
 1. **Service is destroyed**

--- a/test/unit/ServiceRegistry.js
+++ b/test/unit/ServiceRegistry.js
@@ -285,7 +285,7 @@ describe("ServiceRegistry", function () {
             expect(await serviceRegistry.exists(2)).to.equal(false);
         });
 
-        it("Should fail when trying to update the service with already registered agent instances", async function () {
+        it("Should fail when trying to update the service with already active registration", async function () {
             const mechManager = signers[3];
             const serviceManager = signers[4];
             const owner = signers[5].address;
@@ -302,7 +302,7 @@ describe("ServiceRegistry", function () {
             await expect(
                 serviceRegistry.connect(serviceManager).update(owner, name, description, configHash, agentIds,
                     agentParams, maxThreshold, 1)
-            ).to.be.revertedWith("AgentInstanceRegistered");
+            ).to.be.revertedWith("WrongServiceState");
         });
 
         it("Update specifically for hashes, then get service hashes", async function () {
@@ -1025,7 +1025,7 @@ describe("ServiceRegistry", function () {
             // Revert when insufficient amount is passed
             await expect(
                 serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline, {value: 0})
-            ).to.be.revertedWith("InsufficientRegistrationDepositValue");
+            ).to.be.revertedWith("IncorrectRegistrationDepositValue");
 
             // Activate registration and register one agent instance
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline, {value: regDeposit});
@@ -1154,7 +1154,7 @@ describe("ServiceRegistry", function () {
             // Activate registration and register one agent instance
             await expect(
                 serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit - 1})
-            ).to.be.revertedWith("InsufficientRegistrationDepositValue");
+            ).to.be.revertedWith("IncorrectRegistrationDepositValue");
         });
     });
 


### PR DESCRIPTION
### Implemented
- Owner has to make a deposit in order to start agent instance registration;
- The deposit is calculated as the maximum agent instance bonding amount for a specific service;
- The deposit is returned during the termination of the service.
- `update()` function is called only from the `pre-registration` state now.
- Updated FSM.
- Updated tests.