### PR TITLE
refactor: operators can now register agent instances in bulk

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -138,16 +138,16 @@ contract AgentRegistry is IErrors, IStructs, ERC721Enumerable, Ownable, Reentran
     /// @param owner Owner of the agent.
     /// @param tokenId Token Id.
     /// @param agentHash New IPFS hash of the agent.
-    function updateHash(address owner, uint256 tokenId, Multihash memory agentHash)
-        external
-        onlyManager
-        checkHash(agentHash)
+    /// @return success True, if function executed successfully.
+    function updateHash(address owner, uint256 tokenId, Multihash memory agentHash) external onlyManager
+        checkHash(agentHash) returns (bool success)
     {
         if (ownerOf(tokenId) != owner) {
             revert AgentNotFound(tokenId);
         }
         Agent storage agent = _mapTokenIdAgent[tokenId];
         agent.agentHashes.push(agentHash);
+        success = true;
     }
 
     /// @dev Check for the token / agent existence.
@@ -165,9 +165,7 @@ contract AgentRegistry is IErrors, IStructs, ERC721Enumerable, Ownable, Reentran
     /// @return description The agent description.
     /// @return numDependencies The number of components in the dependency list.
     /// @return dependencies The list of component dependencies.
-    function getInfo(uint256 tokenId)
-        public
-        view
+    function getInfo(uint256 tokenId) public view
         returns (address owner, address developer, Multihash memory agentHash, string memory description,
             uint256 numDependencies, uint256[] memory dependencies)
     {
@@ -182,9 +180,7 @@ contract AgentRegistry is IErrors, IStructs, ERC721Enumerable, Ownable, Reentran
     /// @dev Gets component / agent dependencies.
     /// @return numDependencies The number of components in the dependency list.
     /// @return dependencies The list of component dependencies.
-    function getDependencies(uint256 tokenId)
-        public
-        view
+    function getDependencies(uint256 tokenId) public view
         returns (uint256 numDependencies, uint256[] memory dependencies)
     {
         if (!_exists(tokenId)) {
@@ -198,7 +194,9 @@ contract AgentRegistry is IErrors, IStructs, ERC721Enumerable, Ownable, Reentran
     /// @param tokenId Token Id.
     /// @return numHashes Number of hashes.
     /// @return agentHashes The list of agent hashes.
-    function getHashes(uint256 tokenId) public view returns (uint256 numHashes, Multihash[] memory agentHashes) {
+    function getHashes(uint256 tokenId) public view
+        returns (uint256 numHashes, Multihash[] memory agentHashes)
+    {
         if (!_exists(tokenId)) {
             revert AgentNotFound(tokenId);
         }

--- a/contracts/ComponentRegistry.sol
+++ b/contracts/ComponentRegistry.sol
@@ -133,16 +133,17 @@ contract ComponentRegistry is IErrors, IStructs, ERC721Enumerable, Ownable, Reen
     /// @param owner Owner of the component.
     /// @param tokenId Token Id.
     /// @param componentHash New IPFS hash of the component.
-    function updateHash(address owner, uint256 tokenId, Multihash memory componentHash)
-        external
-        onlyManager
+    /// @return success True, if function executed successfully.
+    function updateHash(address owner, uint256 tokenId, Multihash memory componentHash) external onlyManager
         checkHash(componentHash)
+        returns (bool success)
     {
         if (ownerOf(tokenId) != owner) {
             revert ComponentNotFound(tokenId);
         }
         Component storage component = _mapTokenIdComponent[tokenId];
         component.componentHashes.push(componentHash);
+        success = true;
     }
 
     /// @dev Check for the token / component existence.
@@ -160,9 +161,7 @@ contract ComponentRegistry is IErrors, IStructs, ERC721Enumerable, Ownable, Reen
     /// @return description The component description.
     /// @return numDependencies The number of components in the dependency list.
     /// @return dependencies The list of component dependencies.
-    function getInfo(uint256 tokenId)
-        public
-        view
+    function getInfo(uint256 tokenId) public view
         returns (address owner, address developer, Multihash memory componentHash, string memory description,
             uint256 numDependencies, uint256[] memory dependencies)
     {
@@ -177,10 +176,8 @@ contract ComponentRegistry is IErrors, IStructs, ERC721Enumerable, Ownable, Reen
     /// @dev Gets component dependencies.
     /// @return numDependencies The number of components in the dependency list.
     /// @return dependencies The list of component dependencies.
-    function getDependencies(uint256 tokenId)
-    public
-    view
-    returns (uint256 numDependencies, uint256[] memory dependencies)
+    function getDependencies(uint256 tokenId) public view
+        returns (uint256 numDependencies, uint256[] memory dependencies)
     {
         if (!_exists(tokenId)) {
             revert ComponentNotFound(tokenId);
@@ -193,7 +190,9 @@ contract ComponentRegistry is IErrors, IStructs, ERC721Enumerable, Ownable, Reen
     /// @param tokenId Token Id.
     /// @return numHashes Number of hashes.
     /// @return componentHashes The list of component hashes.
-    function getHashes(uint256 tokenId) public view returns (uint256 numHashes, Multihash[] memory componentHashes) {
+    function getHashes(uint256 tokenId) public view
+        returns (uint256 numHashes, Multihash[] memory componentHashes)
+    {
         if (!_exists(tokenId)) {
             revert ComponentNotFound(tokenId);
         }

--- a/contracts/ServiceManager.sol
+++ b/contracts/ServiceManager.sol
@@ -71,42 +71,40 @@ contract ServiceManager is IErrors, IStructs, Ownable {
             threshold, serviceId);
     }
 
-    /// @dev Sets agent instance registration window time.
-    /// @param serviceId Correspondent service Id.
-    /// @param deadline Registration deadline.
-    function serviceSetRegistrationDeadline(uint256 serviceId, uint256 deadline) public {
-        IService(serviceRegistry).setRegistrationDeadline(msg.sender, serviceId, deadline);
-    }
-
     /// @dev Terminates the service.
     /// @param serviceId Service Id.
-    function serviceTerminate(uint256 serviceId) public {
-        IService(serviceRegistry).terminate(msg.sender, serviceId);
+    /// @return success True, if function executed successfully.
+    /// @return refund Refund to return to the owner.
+    function serviceTerminate(uint256 serviceId) public returns (bool success, uint256 refund) {
+        (success, refund) = IService(serviceRegistry).terminate(msg.sender, serviceId);
     }
 
     /// @dev Destroys the service instance and frees up its storage.
     /// @param serviceId Correspondent service Id.
-    function serviceDestroy(uint256 serviceId) public {
-        IService(serviceRegistry).destroy(msg.sender, serviceId);
+    /// @return success True, if function executed successfully.
+    function serviceDestroy(uint256 serviceId) public returns (bool success) {
+        success = IService(serviceRegistry).destroy(msg.sender, serviceId);
     }
 
     /// @dev Unbonds agent instances of the operator from the service.
     /// @param serviceId Service Id.
-    /// @return refund The refund amount.
-    function serviceUnbond(uint256 serviceId) public returns (uint256 refund) {
-        return IService(serviceRegistry).unbond(msg.sender, serviceId);
+    /// @return success True, if function executed successfully.
+    /// @return refund The amount of refund returned to the operator.
+    function serviceUnbond(uint256 serviceId) public returns (bool success, uint256 refund) {
+        (success, refund) = IService(serviceRegistry).unbond(msg.sender, serviceId);
     }
 
     /// @dev Registers agent instances.
     /// @param serviceId Service Id to be updated.
     /// @param agentInstances Agent instance addresses.
     /// @param agentIds Canonical Ids of the agent correspondent to the agent instance.
+    /// @return success True, if function executed successfully.
     function serviceRegisterAgents(
         uint256 serviceId,
         address[] memory agentInstances,
         uint256[] memory agentIds
-    ) public payable {
-        IService(serviceRegistry).registerAgents{value: msg.value}(msg.sender, serviceId, agentInstances, agentIds);
+    ) public payable returns (bool success) {
+        success = IService(serviceRegistry).registerAgents{value: msg.value}(msg.sender, serviceId, agentInstances, agentIds);
     }
 
     /// @dev Creates Safe instance controlled by the service agent instances.
@@ -136,8 +134,8 @@ contract ServiceManager is IErrors, IStructs, Ownable {
 
     /// @dev Activates the service and its sensitive components.
     /// @param serviceId Correspondent service Id.
-    /// @param deadline Agent instance registration deadline.
-    function serviceActivateRegistration(uint256 serviceId, uint256 deadline) public payable {
-        IService(serviceRegistry).activateRegistration{value: msg.value}(msg.sender, serviceId, deadline);
+    /// @return success True, if function executed successfully.
+    function serviceActivateRegistration(uint256 serviceId) public payable returns (bool success) {
+        success = IService(serviceRegistry).activateRegistration{value: msg.value}(msg.sender, serviceId);
     }
 }

--- a/contracts/interfaces/IErrors.sol
+++ b/contracts/interfaces/IErrors.sol
@@ -61,9 +61,9 @@ interface IErrors {
     /// @param serviceId Service Id.
     error ServiceDoesNotExist(uint256 serviceId);
 
-    /// @dev Agent instance is already registered with a specified `serviceId`.
-    /// @param serviceId Service Id.
-    error AgentInstanceRegistered(uint256 serviceId);
+    /// @dev Agent instance is already registered with a specified `operator`.
+    /// @param operator Operator that registered an instance.
+    error AgentInstanceRegistered(address operator);
 
     /// @dev Wrong operator is specified when interacting with a specified `serviceId`.
     /// @param serviceId Service Id.
@@ -90,12 +90,6 @@ interface IErrors {
     /// @param serviceId Service Id.
     error ServiceMustBeInactive(uint256 serviceId);
 
-    /// @dev Agent instance registration deadline has been reached. Service is expired.
-    /// @param deadline The registration deadline.
-    /// @param curBlock Current block.
-    /// @param serviceId Service Id.
-    error RegistrationTimeout(uint256 deadline, uint256 curBlock, uint256 serviceId);
-
     /// @dev Service termination block has been reached. Service is terminated.
     /// @param teminationBlock The termination block.
     /// @param curBlock Current block.
@@ -116,18 +110,6 @@ interface IErrors {
     /// @param state Service state.
     /// @param serviceId Service Id.
     error WrongServiceState(uint256 state, uint256 serviceId);
-
-    /// @dev Registration deadline of the agent instance is incorrect (past block).
-    /// @param deadline Provided deadline.
-    /// @param minBlock The deadline must to be greater than the minimum block number.
-    /// @param serviceId Service Id.
-    error RegistrationDeadlineIncorrect(uint256 deadline, uint256 minBlock, uint256 serviceId);
-
-    /// @dev Registration deadline change is redundant if provided deadline is greater than the previous one.
-    /// @param deadline Provided deadline.
-    /// @param prevDeadline Previous deadline.
-    /// @param serviceId Service Id.
-    error RegistrationDeadlineChangeRedundant(uint256 deadline, uint256 prevDeadline, uint256 serviceId);
 
     /// @dev Only own service multisig is allowed.
     /// @param provided Provided address.

--- a/contracts/interfaces/IService.sol
+++ b/contracts/interfaces/IService.sol
@@ -10,8 +10,8 @@ interface IService is IStructs {
     /// @dev Activates the service.
     /// @param owner Individual that creates and controls a service.
     /// @param serviceId Correspondent service Id.
-    /// @param deadline Agent instance registration deadline.
-    function activateRegistration(address owner, uint256 serviceId, uint256 deadline) external payable;
+    /// @return success True, if function executed successfully.
+    function activateRegistration(address owner, uint256 serviceId) external payable returns (bool success);
 
     /// @dev Creates a new service.
     /// @param owner Individual that creates and controls a service.
@@ -52,39 +52,38 @@ interface IService is IStructs {
         uint256 serviceId
     ) external;
 
-    /// @dev Sets agent instance registration deadline.
-    /// @param owner Individual that creates and controls a service.
-    /// @param serviceId Service Id to be updated.
-    /// @param deadline Registration deadline.
-    function setRegistrationDeadline(address owner, uint256 serviceId, uint256 deadline) external;
-
     /// @dev Terminates the service.
     /// @param owner Owner of the service.
     /// @param serviceId Service Id to be updated.
-    function terminate(address owner, uint256 serviceId) external;
+    /// @return success True, if function executed successfully.
+    /// @return refund Refund to return to the owner.
+    function terminate(address owner, uint256 serviceId) external returns (bool success, uint256 refund);
 
     /// @dev Destroys the service instance.
     /// @param owner Individual that creates and controls a service.
     /// @param serviceId Correspondent service Id.
-    function destroy(address owner, uint256 serviceId) external;
+    /// @return success True, if function executed successfully.
+    function destroy(address owner, uint256 serviceId) external returns (bool success);
 
     /// @dev Unbonds agent instances of the operator from the service.
     /// @param operator Operator of agent instances.
     /// @param serviceId Service Id.
-    /// @return refund The refund amount.
-    function unbond(address operator, uint256 serviceId) external returns (uint256 refund);
+    /// @return success True, if function executed successfully.
+    /// @return refund The amount of refund returned to the operator.
+    function unbond(address operator, uint256 serviceId) external returns (bool success, uint256 refund);
 
     /// @dev Registers agent instances.
     /// @param operator Address of the operator.
     /// @param serviceId Service Id to be updated.
     /// @param agentInstances Agent instance addresses.
     /// @param agentIds Canonical Ids of the agent correspondent to the agent instance.
+    /// @return success True, if function executed successfully.
     function registerAgents(
         address operator,
         uint256 serviceId,
         address[] memory agentInstances,
         uint256[] memory agentIds
-    ) external payable;
+    ) external payable returns (bool success);
 
     /// @dev Creates Gnosis Safe instance controlled by the service agent instances.
     /// @param owner Individual that creates and controls a service.
@@ -95,7 +94,7 @@ interface IService is IStructs {
     /// @param paymentToken Token that should be used for the payment (0 is ETH)
     /// @param payment Value that should be paid
     /// @param paymentReceiver Adddress that should receive the payment (or 0 if tx.origin)
-    /// @return Address of the created multisig.
+    /// @return multisig Address of the created multisig.
     function createSafe(
         address owner,
         uint256 serviceId,
@@ -106,5 +105,5 @@ interface IService is IStructs {
         uint256 payment,
         address payable paymentReceiver,
         uint256 nonce
-    ) external returns (address);
+    ) external returns (address multisig);
 }

--- a/contracts/interfaces/IStructs.sol
+++ b/contracts/interfaces/IStructs.sol
@@ -13,14 +13,6 @@ interface IStructs {
         uint256 bond;
     }
 
-    // Operator and service Id where operator registers agent instances
-    struct OperatorServiceId {
-        // Operator address
-        address operator;
-        // Service Id
-        uint256 serviceId;
-    }
-
     // Multihash according to self-describing hashes standard. For more information of multihashes please visit https://multiformats.io/multihash/
     struct Multihash {
         // IPFS uses a sha2-256 hashing function. Each IPFS hash has to start with 1220.

--- a/test/integration/ServiceRegistryManager.js
+++ b/test/integration/ServiceRegistryManager.js
@@ -27,9 +27,6 @@ describe("ServiceRegistry integration", function () {
     const componentHash2 = {hash: "0x" + "2".repeat(64), hashFunction: "0x12", size: "0x20"};
     const nonce =  0;
     const AddressZero = "0x" + "0".repeat(40);
-    // Deadline must be bigger than minimum deadline plus current block number. However hardhat keeps on increasing
-    // block number for each test, so we set a high enough value here, and in time sensitive tests use current blocks
-    const regDeadline = 100000;
     beforeEach(async function () {
         const ComponentRegistry = await ethers.getContractFactory("ComponentRegistry");
         componentRegistry = await ComponentRegistry.deploy("agent components", "MECHCOMP",
@@ -96,8 +93,8 @@ describe("ServiceRegistry integration", function () {
                 maxThreshold);
             await serviceManager.serviceCreate(owner.address, name, description, configHash, agentIds, agentParams,
                 maxThreshold);
-            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], regDeadline, {value: regDeposit});
-            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[1], regDeadline, {value: regDeposit});
+            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], {value: regDeposit});
+            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[1], {value: regDeposit});
             await serviceManager.connect(operator).serviceRegisterAgents(serviceIds[0], [agentInstances[0], agentInstances[2]],
                 [agentIds[0], agentIds[0]], {value: 2*regBond});
             await serviceManager.connect(operator).serviceRegisterAgents(serviceIds[1], [agentInstances[1]], [agentIds[1]], {value: regBond});
@@ -163,8 +160,8 @@ describe("ServiceRegistry integration", function () {
             expect(state).to.equal(1);
 
             // Activate the registration
-            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], regDeadline, {value: regDeposit});
-            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[1], regDeadline, {value: regDeposit});
+            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], {value: regDeposit});
+            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[1], {value: regDeposit});
             state = await serviceRegistry.getServiceState(serviceIds[0]);
             expect(state).to.equal(2);
 
@@ -220,7 +217,7 @@ describe("ServiceRegistry integration", function () {
             const newMaxThreshold = newAgentParams[0][0] + newAgentParams[1][0];
             await serviceManager.serviceCreate(owner.address, name, description, configHash, newAgentIds,
                 newAgentParams, newMaxThreshold);
-            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], regDeadline, {value: regDeposit});
+            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], {value: regDeposit});
 
             // Registering agents for service Id == 1
             await serviceManager.connect(operators[0]).serviceRegisterAgents(serviceIds[0], [agentInstances[0], agentInstances[1]],
@@ -244,9 +241,6 @@ describe("ServiceRegistry integration", function () {
                 serviceManager.connect(operators[1]).serviceRegisterAgents(serviceIds[0], [agentInstances[3]],
                     [newAgentIds[1]], {value: regBond})
             ).to.be.revertedWith("WrongServiceState");
-
-            // Since all instances are registered, we can change the deadline now
-            await serviceManager.connect(owner).serviceSetRegistrationDeadline(serviceIds[0], regDeadline - 10);
 
             // Creating Safe with blanc safe parameters for the test
             const safe = await serviceManager.connect(owner).serviceCreateSafe(serviceIds[0], AddressZero, "0x",
@@ -303,7 +297,7 @@ describe("ServiceRegistry integration", function () {
             }
 
             // Activate registration and terminate the very first service and destroy it
-            await serviceManager.connect(sigOwner).serviceActivateRegistration(serviceIds[0], regDeadline, {value: regDeposit});
+            await serviceManager.connect(sigOwner).serviceActivateRegistration(serviceIds[0], {value: regDeposit});
             await serviceManager.connect(sigOwner).serviceTerminate(serviceIds[0]);
             await serviceManager.connect(sigOwner).serviceDestroy(serviceIds[0]);
 
@@ -338,7 +332,7 @@ describe("ServiceRegistry integration", function () {
                 [[maxThreshold, regBond]], maxThreshold);
 
             // Activate agent instance registration and register an agent instance
-            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], regDeadline, {value: regDeposit});
+            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], {value: regDeposit});
             await serviceManager.connect(operator).serviceRegisterAgents(serviceIds[0], [agentInstances[0]],
                 [agentIds[0]], {value: regBond});
 
@@ -354,12 +348,12 @@ describe("ServiceRegistry integration", function () {
             // Terminate the service before it's deployed
             await serviceManager.connect(owner).serviceTerminate(serviceIds[0]);
             let state = await serviceRegistry.getServiceState(serviceIds[0]);
-            expect(state).to.equal(6);
+            expect(state).to.equal(5);
 
             // Unbond agent instances. Since all the agents will eb unbonded, the service state is terminated-unbonded
             await serviceManager.connect(operator).serviceUnbond(serviceIds[0]);
             state = await serviceRegistry.getServiceState(serviceIds[0]);
-            expect(state).to.equal(7);
+            expect(state).to.equal(6);
         });
 
         it("Should fail when trying to update the terminated service is destroyed", async function () {
@@ -377,7 +371,7 @@ describe("ServiceRegistry integration", function () {
                 maxThreshold);
             await serviceManager.serviceCreate(owner.address, name, description, configHash, agentIds, agentParams,
                 maxThreshold);
-            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], regDeadline, {value: regDeposit});
+            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], {value: regDeposit});
             await serviceManager.connect(owner).serviceTerminate(serviceIds[0]);
             await serviceManager.connect(owner).serviceDestroy(serviceIds[0]);
             await expect(
@@ -386,7 +380,7 @@ describe("ServiceRegistry integration", function () {
             ).to.be.revertedWith("ServiceNotFound");
         });
 
-        it("Should fail when registering an agent instance after the timeout", async function () {
+        it("Should fail when registering an agent instance after the service is destroyed", async function () {
             const mechManager = signers[4];
             const owner = signers[5];
             const operator = signers[6];
@@ -397,20 +391,10 @@ describe("ServiceRegistry integration", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceManager.serviceCreate(owner.address, name, description, configHash, agentIds, agentParams,
                 maxThreshold);
-            const nBlocks = Number(await serviceRegistry.getMinRegistrationDeadline());
-            const blockNumber = await ethers.provider.getBlockNumber();
-            // Deadline must be bigger than a current block number plus the minimum registration deadline
-            const tDeadline = blockNumber + nBlocks + 10;
-            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], tDeadline, {value: regBond});
-            // Mining past the deadline
-            for (let i = blockNumber; i <= tDeadline; i++) {
-                ethers.provider.send("evm_mine");
-            }
+            await serviceManager.connect(owner).serviceDestroy(serviceIds[0]);
             await expect(
                 serviceManager.connect(operator).serviceRegisterAgents(serviceIds[0], [agentInstance], [1], {value: regBond})
-            ).to.be.revertedWith("RegistrationTimeout");
-            const state = await serviceRegistry.getServiceState(serviceIds[0]);
-            expect(state).to.equal(3);
+            ).to.be.revertedWith("WrongServiceState");
         });
     });
 
@@ -442,7 +426,7 @@ describe("ServiceRegistry integration", function () {
 
             // Creating a service and activating registration
             await serviceManager.serviceCreate(owner.address, name, description, configHash, [1], [[1, regBond]], 1);
-            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], regDeadline, {value: regDeposit});
+            await serviceManager.connect(owner).serviceActivateRegistration(serviceIds[0], {value: regDeposit});
 
             // Registering agent instance
             await serviceManager.connect(operator).serviceRegisterAgents(serviceIds[0], [agentInstance.address],
@@ -481,9 +465,9 @@ describe("ServiceRegistry integration", function () {
             // Terminate service and unbond the operator
             await serviceManager.connect(owner).serviceTerminate(serviceIds[0]);
             // Use the static call first that emulates the call, to get the return value of a refund
-            const refund = await serviceManager.connect(operator).callStatic.serviceUnbond(serviceIds[0]);
+            const unbond = await serviceManager.connect(operator).callStatic.serviceUnbond(serviceIds[0]);
             // The refund for unbonding is the bond minus the fine
-            expect(Number(refund)).to.equal(balanceOperator - regFine);
+            expect(Number(unbond.refund)).to.equal(balanceOperator - regFine);
 
             // Do the real unbond call
             await serviceManager.connect(operator).serviceUnbond(serviceIds[0]);

--- a/test/unit/ServiceRegistry.js
+++ b/test/unit/ServiceRegistry.js
@@ -28,9 +28,6 @@ describe("ServiceRegistry", function () {
     const agentHash = {hash: "0x" + "7".repeat(64), hashFunction: "0x12", size: "0x20"};
     const agentHash1 = {hash: "0x" + "8".repeat(64), hashFunction: "0x12", size: "0x20"};
     const AddressZero = "0x" + "0".repeat(40);
-    // Deadline must be bigger than minimum deadline plus current block number. However hardhat keeps on increasing
-    // block number for each test, so we set a high enough value here, and in time sensitive tests use current blocks
-    const regDeadline = 100000;
     beforeEach(async function () {
         const ComponentRegistry = await ethers.getContractFactory("ComponentRegistry");
         componentRegistry = await ComponentRegistry.deploy("agent components", "MECHCOMP",
@@ -298,7 +295,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
             await expect(
                 serviceRegistry.connect(serviceManager).update(owner, name, description, configHash, agentIds,
@@ -384,7 +381,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
             await expect(
                 serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond})
@@ -403,7 +400,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
                 serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [0])
             ).to.be.revertedWith("AgentNotInService");
@@ -422,7 +419,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
                 serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, agentInstances, regAgentIds, {value: 4*regBond})
             ).to.be.revertedWith("AgentInstancesSlotsFilled");
@@ -440,7 +437,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             const regAgent = await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId,
                 [agentInstance], [agentId], {value: regBond});
             const result = await regAgent.wait();
@@ -461,8 +458,8 @@ describe("ServiceRegistry", function () {
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance[0]],
                 [agentId], {value: regBond});
             const regAgent = await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId + 1,
@@ -483,7 +480,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
                 serviceRegistry.connect(serviceManager).registerAgents(agentInstances[0], serviceId, [agentInstances[0]],
                     [agentId], {value: regBond})
@@ -501,7 +498,7 @@ describe("ServiceRegistry", function () {
         it("Should fail when activating a service without a serviceManager", async function () {
             const owner = signers[3].address;
             await expect(
-                serviceRegistry.activateRegistration(owner, serviceId, regDeadline, {value: regDeposit})
+                serviceRegistry.activateRegistration(owner, serviceId, {value: regDeposit})
             ).to.be.revertedWith("ManagerOnly");
         });
 
@@ -510,7 +507,7 @@ describe("ServiceRegistry", function () {
             const owner = signers[4].address;
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1, regDeadline, {value: regDeposit})
+                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1, {value: regDeposit})
             ).to.be.revertedWith("ServiceNotFound");
         });
 
@@ -524,9 +521,9 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
-                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit})
+                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit})
             ).to.be.revertedWith("ServiceMustBeInactive");
         });
 
@@ -542,7 +539,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
             const activateService = await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId,
-                regDeadline, {value: regDeposit});
+                {value: regDeposit});
             const result = await activateService.wait();
             expect(result.events[0].event).to.equal("ActivateRegistration");
         });
@@ -557,10 +554,11 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             const terminateService = await serviceRegistry.connect(serviceManager).terminate(owner, serviceId);
             const result = await terminateService.wait();
-            expect(result.events[0].event).to.equal("TerminateService");
+            expect(result.events[0].event).to.equal("Refund");
+            expect(result.events[1].event).to.equal("TerminateService");
         });
 
         it("Destroying a service with at least one agent instance", async function () {
@@ -570,17 +568,27 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
 
+            // Create agents and a service
             await agentRegistry.changeManager(mechManager.address);
             await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
             await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+
+            // Activate registration and register and agent instance
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
+
+            // Terminate the service, unbond, destroy
             const terminateService = await serviceRegistry.connect(serviceManager).terminate(owner, serviceId);
-            const result = await terminateService.wait();
-            expect(result.events[0].event).to.equal("TerminateService");
+            let result = await terminateService.wait();
+            expect(result.events[0].event).to.equal("Refund");
+            expect(result.events[1].event).to.equal("TerminateService");
+            await serviceRegistry.connect(serviceManager).unbond(operator, serviceId);
+            const destroyService = await serviceRegistry.connect(serviceManager).destroy(owner, serviceId);
+            result = await destroyService.wait();
+            expect(result.events[2].event).to.equal("DestroyService");
         });
     });
 
@@ -597,7 +605,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
             await expect(
                 serviceRegistry.connect(serviceManager).createSafe(owner, serviceId, AddressZero, "0x", AddressZero,
@@ -633,21 +641,15 @@ describe("ServiceRegistry", function () {
             state = await serviceRegistry.getServiceState(serviceId);
             expect(state).to.equal(1);
 
-            const nBlocks = Number(await serviceRegistry.getMinRegistrationDeadline());
-            const blockNumber = await ethers.provider.getBlockNumber();
-            // Deadline must be bigger than a current block number plus the minimum registration deadline
-            const tDeadline = blockNumber + nBlocks + 10;
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             state = await serviceRegistry.getServiceState(serviceId);
             expect(state).to.equal(2);
-            const registartionDeadline = await serviceRegistry.getRegistrationDeadline(serviceId);
-            expect(registartionDeadline).to.equal(tDeadline);
 
             /// Register agent instances
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, agentInstances,
                 regAgentIds, {value: 3*regBond});
             state = await serviceRegistry.getServiceState(serviceId);
-            expect(state).to.equal(4);
+            expect(state).to.equal(3);
 
             // Create safe
             const safe = await serviceRegistry.connect(serviceManager).createSafe(owner, serviceId, AddressZero, "0x",
@@ -655,7 +657,7 @@ describe("ServiceRegistry", function () {
             const result = await safe.wait();
             expect(result.events[2].event).to.equal("CreateSafeWithAgents");
             state = await serviceRegistry.getServiceState(serviceId);
-            expect(state).to.equal(5);
+            expect(state).to.equal(4);
 
             // Check the service info
             const serviceIdFromAgentId = await serviceRegistry.getServiceIdsCreatedWithAgentId(agentId);
@@ -695,8 +697,8 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash1, [2],
                 [[2, regBond]], maxThreshold);
 
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1, {value: regDeposit});
 
             /// Register agent instances
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstances[0], agentInstances[1]],
@@ -835,7 +837,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, agentInstances,
                 regAgentIds, {value: 2*regBond});
 
@@ -856,97 +858,6 @@ describe("ServiceRegistry", function () {
             await expect(
                 serviceRegistry.getConfigHashes(1)
             ).to.be.revertedWith("ServiceDoesNotExist");
-        });
-    });
-
-    context("Deadlines", async function () {
-        it("Manipulations with registration deadlines", async function () {
-            const mechManager = signers[3];
-            const serviceManager = signers[4];
-            const owner = signers[5].address;
-            const operator = signers[6].address;
-            const agentInstances = [signers[7].address, signers[8].address];
-            const regAgentIds = [agentId, agentId];
-            const maxThreshold = 2;
-
-            // Create a component
-            await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-
-            // Create an agent
-            await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash2, description, [1]);
-
-            // Create a service and activate the agent instance registration
-            await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1],
-                [[2, regBond]], maxThreshold);
-
-            const nBlocks = Number(await serviceRegistry.getMinRegistrationDeadline());
-            const blockNumber = await ethers.provider.getBlockNumber();
-            // Deadline must be bigger than a current block number plus the minimum registration deadline
-            const tDeadline = blockNumber + nBlocks + 10;
-            // Rejects if the registration deadline is not bigger than the minimum deadline
-            await expect(
-                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, blockNumber + nBlocks, {value: regDeposit})
-            ).to.be.revertedWith("RegistrationDeadlineIncorrect");
-            // Now deadline has a correct value
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline, {value: regDeposit});
-
-            /// Register agent instances
-            await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, agentInstances,
-                regAgentIds, {value: 2*regBond});
-
-            // Since all instances are registered, we can change the deadline now to the current block
-            const newBlockNumber = await ethers.provider.getBlockNumber() + 1;
-            await serviceRegistry.connect(serviceManager).setRegistrationDeadline(owner, serviceId, newBlockNumber);
-
-            // Cannot go below current block though
-            await expect(
-                serviceRegistry.connect(serviceManager).setRegistrationDeadline(owner, serviceId, 0)
-            ).to.be.revertedWith("RegistrationDeadlineIncorrect");
-
-            // It is not allowed also to move to a bigger block when all the instances are registered
-            await expect(
-                serviceRegistry.connect(serviceManager).setRegistrationDeadline(owner, serviceId, newBlockNumber + 10)
-            ).to.be.revertedWith("RegistrationDeadlineChangeRedundant");
-        });
-
-        it("Setting different registration deadlines", async function () {
-            const mechManager = signers[3];
-            const serviceManager = signers[4];
-            const owner = signers[5].address;
-            const maxThreshold = 2;
-
-            // Create a component
-            await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-
-            // Create an agent
-            await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash2, description, [1]);
-
-            // Create a service and activate the agent instance registration
-            await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1],
-                [[2, regBond]], maxThreshold);
-
-            // Trying to set the registration deadline before the registration is activated
-            await expect(
-                serviceRegistry.connect(serviceManager).setRegistrationDeadline(owner, serviceId, regDeadline)
-            ).to.be.revertedWith("WrongServiceState");
-
-            const nBlocks = Number(await serviceRegistry.getMinRegistrationDeadline());
-            const blockNumber = await ethers.provider.getBlockNumber();
-            // Deadline must be bigger than a current block number plus the minimum registration deadline
-            const tDeadline = blockNumber + nBlocks + 10;
-
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline, {value: regDeposit});
-
-            // Trying to change the registration deadline below the minimum on while no one has registered yet
-            await expect(
-                serviceRegistry.connect(serviceManager).setRegistrationDeadline(owner, serviceId, nBlocks)
-            ).to.be.revertedWith("RegistrationDeadlineIncorrect");
         });
     });
 
@@ -990,13 +901,13 @@ describe("ServiceRegistry", function () {
                 [[2, regBond]], maxThreshold);
 
             // Activate registration and register one agent instance
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
 
             // Terminating service with a registered agent instance will give it a terminated-bonded state
             await serviceRegistry.connect(serviceManager).terminate(owner, serviceId);
             const state = await serviceRegistry.getServiceState(serviceId);
-            expect(state).to.equal(6);
+            expect(state).to.equal(5);
 
             // Trying to terminate it again will revert
             await expect(
@@ -1004,7 +915,7 @@ describe("ServiceRegistry", function () {
             ).to.be.revertedWith("WrongServiceState");
         });
 
-        it("Unbond when the service registration is expired", async function () {
+        it("Unbond when the service registration is terminated", async function () {
             const mechManager = signers[3];
             const serviceManager = signers[4];
             const owner = signers[5].address;
@@ -1021,18 +932,13 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
-            // Setting a registration deadline that will need to be expired
-            const nBlocks = Number(await serviceRegistry.getMinRegistrationDeadline());
-            const blockNumber = await ethers.provider.getBlockNumber();
-            const tDeadline = blockNumber + nBlocks + 10;
-
             // Revert when insufficient amount is passed
             await expect(
-                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline, {value: 0})
+                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: 0})
             ).to.be.revertedWith("IncorrectRegistrationDepositValue");
 
             // Activate registration and register one agent instance
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
             // Balance of the operator must be regBond
             const balanceOperator = Number(await serviceRegistry.getOperatorBalance(operator, serviceId));
@@ -1041,17 +947,7 @@ describe("ServiceRegistry", function () {
             const contractBalance = Number(await ethers.provider.getBalance(serviceRegistry.address));
             expect(contractBalance).to.equal(regBond + regDeposit);
 
-            // Trying to unbond before the deadline expiration
-            await expect(
-                serviceRegistry.connect(serviceManager).unbond(operator, serviceId)
-            ).to.be.revertedWith("WrongServiceState");
-
-            // Mining past the deadline
-            for (let i = blockNumber; i <= tDeadline; i++) {
-                ethers.provider.send("evm_mine");
-            }
-
-            // Try to unbond without termination of the service
+            // Trying to unbond before the service is terminated
             await expect(
                 serviceRegistry.connect(serviceManager).unbond(operator, serviceId)
             ).to.be.revertedWith("WrongServiceState");
@@ -1067,9 +963,10 @@ describe("ServiceRegistry", function () {
             // Unbonding
             const unbondTx = await serviceRegistry.connect(serviceManager).unbond(operator, serviceId);
             const result = await unbondTx.wait();
-            expect(result.events[0].event).to.equal("OperatorUnbond");
+            expect(result.events[0].event).to.equal("Refund");
+            expect(result.events[1].event).to.equal("OperatorUnbond");
             const state = await serviceRegistry.getServiceState(serviceId);
-            expect(state).to.equal(7);
+            expect(state).to.equal(6);
 
             // Operator's balance after unbonding must be zero
             const newBalanceOperator = Number(await serviceRegistry.getOperatorBalance(operator, serviceId));
@@ -1093,7 +990,7 @@ describe("ServiceRegistry", function () {
                 [[2, regBond]], maxThreshold);
 
             // Activate registration and try to unbond
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
                 serviceRegistry.connect(serviceManager).unbond(operator, serviceId)
             ).to.be.revertedWith("WrongServiceState");
@@ -1129,13 +1026,8 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
-            // Setting a registration deadline that will need to be expired
-            const nBlocks = Number(await serviceRegistry.getMinRegistrationDeadline());
-            const blockNumber = await ethers.provider.getBlockNumber();
-            const tDeadline = blockNumber + nBlocks + 10;
-
             // Activate registration and register one agent instance
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, tDeadline, {value: regBond});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regBond});
             await expect(
                 serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance],
                     [agentId], {value: 0})
@@ -1159,7 +1051,7 @@ describe("ServiceRegistry", function () {
 
             // Activate registration and register one agent instance
             await expect(
-                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit - 1})
+                serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit - 1})
             ).to.be.revertedWith("IncorrectRegistrationDepositValue");
         });
 
@@ -1182,7 +1074,7 @@ describe("ServiceRegistry", function () {
                 agentParams, maxThreshold);
 
             // Activate registration and register an agent instance
-            serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
 
             // Should fail when dimentions of arrays don't match
@@ -1216,7 +1108,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1],
                 [[1, regBond]], maxThreshold);
 
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
 
             /// Register agent instance
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance.address], [agentId], {value: regBond});
@@ -1271,7 +1163,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
 
             /// Register agent instance
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId,
@@ -1322,8 +1214,8 @@ describe("ServiceRegistry", function () {
 
             // Terminate service and unbond. The operator won't get any refund
             await serviceRegistry.connect(serviceManager).terminate(owner, serviceId);
-            const refund = await serviceRegistry.connect(serviceManager).callStatic.unbond(operator, serviceId);
-            expect(Number(refund)).to.equal(0);
+            const unbond = await serviceRegistry.connect(serviceManager).callStatic.unbond(operator, serviceId);
+            expect(Number(unbond.refund)).to.equal(0);
         });
 
         it("Reward a service twice, get its reward balance", async function () {
@@ -1350,7 +1242,7 @@ describe("ServiceRegistry", function () {
     });
 
     context("Destroying the service", async function () {
-        it("Should fail when calling destroy not from temnitated state", async function () {
+        it("Should fail when calling destroy not from temnitated or pre-registration state", async function () {
             const mechManager = signers[3];
             const serviceManager = signers[4];
             const owner = signers[5].address;
@@ -1363,13 +1255,8 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
 
-            // Trying to call destroy from pre-existent
-            await expect(
-                serviceRegistry.connect(serviceManager).destroy(owner, serviceId)
-            ).to.be.revertedWith("WrongServiceState");
-
             // Activate registration
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
                 serviceRegistry.connect(serviceManager).destroy(owner, serviceId)
             ).to.be.revertedWith("WrongServiceState");
@@ -1385,7 +1272,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).createService(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, regDeadline, {value: regDeposit});
+            await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).terminate(owner, serviceId);
             const destroyService = await serviceRegistry.connect(serviceManager).destroy(owner, serviceId);
             const result = await destroyService.wait();


### PR DESCRIPTION
- Making `registerAgents()` symmetrical to `unbond()`. Now the operators can register their agent instances in bulk.
- Updating tests.