### PR TITLE
docs:update compile instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The tests are logically separated into unit and integration ones.
 ## Compile the code and run
 Compile the code:
 ```
-npx hardhat compile
+npm run compile
 ```
 Run the tests:
 ```


### PR DESCRIPTION
`npx hardhat compile` fails because of solidity version mismatch resulting in several errors in the form of `Explicit type conversion not allowed from "int_const -1" to "uint128"`