### PR TITLE
chore: renaming governance contract name

### DIFF
--- a/contracts/governance/GovernorOLA.sol
+++ b/contracts/governance/GovernorOLA.sol
@@ -19,7 +19,7 @@ contract GovernorOLA is Governor, GovernorSettings, GovernorCompatibilityBravo, 
         uint256 initialProposalThreshold,
         uint256 quorumFraction
     )
-        Governor("GovernorBravoOLA")
+        Governor("Governor OLA")
         GovernorSettings(initialVotingDelay, initialVotingPeriod, initialProposalThreshold)
         GovernorVotes(governanceToken)
         GovernorVotesQuorumFraction(quorumFraction)

--- a/deploy/contracts.js
+++ b/deploy/contracts.js
@@ -173,7 +173,7 @@ module.exports = async () => {
     console.log("OLA token deployed to", token.address);
 
     const VotingEscrow = await ethers.getContractFactory("VotingEscrow");
-    const escrow = await VotingEscrow.deploy(token.address, "Governance OLA", "veOLA");
+    const escrow = await VotingEscrow.deploy(token.address, "Voting Escrow OLA", "veOLA");
     await escrow.deployed();
     console.log("Voting Escrow deployed to", escrow.address);
 

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -166,7 +166,7 @@ async function main() {
     console.log("OLA token deployed to", token.address);
 
     const VotingEscrow = await ethers.getContractFactory("VotingEscrow");
-    const escrow = await VotingEscrow.deploy(token.address, "Governance OLA", "veOLA");
+    const escrow = await VotingEscrow.deploy(token.address, "Voting Escrow OLA", "veOLA");
     await escrow.deployed();
     console.log("Voting Escrow deployed to", escrow.address);
 

--- a/test/integration/GovernanceControl.js
+++ b/test/integration/GovernanceControl.js
@@ -41,7 +41,7 @@ describe("Governance integration", function () {
 
         // Dispenser address is irrelevant in these tests, so its contract is passed as a zero address
         const VotingEscrow = await ethers.getContractFactory("VotingEscrow");
-        ve = await VotingEscrow.deploy(token.address, "Governance OLA", "veOLA");
+        ve = await VotingEscrow.deploy(token.address, "Voting Escrow OLA", "veOLA");
         await ve.deployed();
 
         signers = await ethers.getSigners();

--- a/test/integration/TokenomicsLoop.js
+++ b/test/integration/TokenomicsLoop.js
@@ -118,7 +118,7 @@ describe("Tokenomics integration", async () => {
         // Correct depository address is missing here, it will be defined just one line below
         treasury = await treasuryFactory.deploy(ola.address, deployer.address, tokenomics.address, deployer.address);
         depository = await depositoryFactory.deploy(ola.address, treasury.address, tokenomics.address);
-        ve = await veFactory.deploy(ola.address, "Governance OLA", "veOLA");
+        ve = await veFactory.deploy(ola.address, "Voting Escrow OLA", "veOLA");
         dispenser = await dispenserFactory.deploy(ola.address, tokenomics.address);
         // Change to the correct addresses
         await tokenomics.changeManagers(treasury.address, depository.address, dispenser.address, ve.address);

--- a/test/unit/governance/Governance.js
+++ b/test/unit/governance/Governance.js
@@ -39,7 +39,7 @@ describe("Governance unit", function () {
 
         // Dispenser address is irrelevant in these tests, so its contract is passed as a zero address
         const VotingEscrow = await ethers.getContractFactory("VotingEscrow");
-        ve = await VotingEscrow.deploy(token.address, "Governance OLA", "veOLA");
+        ve = await VotingEscrow.deploy(token.address, "Voting Escrow OLA", "veOLA");
         await ve.deployed();
 
         signers = await ethers.getSigners();


### PR DESCRIPTION
- Renaming `GovernanceBravoOLA` to `GovernanceOLA`;
- Renaming `GovernanceOLA` to `Voting Escrow OLA` naming of veOLA contracts in tests such that it is not confusing.